### PR TITLE
fix overview link 404

### DIFF
--- a/layouts/sidebar.html
+++ b/layouts/sidebar.html
@@ -8,7 +8,7 @@
 
 <h4 class="sidebar-title">Reference v1</h4>
 <ul class="nav-list">
-  <li><a href="/v1/overview/">Overview</a></li>
+  <li><a href="/v1/">Overview</a></li>
   <li><ul class="nav-list">
   <li><a href="/v1/authentication/">Authentication</a></li>
   </ul></li>


### PR DESCRIPTION
The Overview link currently links to /v1/overview/ which doesn't exist.
The Overview actually lives at /v1/