### PR TITLE
v2 pagination: can return maximum 100 per page

### DIFF
--- a/content/v2.markdown
+++ b/content/v2.markdown
@@ -151,7 +151,7 @@ For example:
 You may include the following arguments as query parameters when you call an API endpoint that supports pagination:
 
 - `page`: The page to return (default: 1)
-- `per_page`: The number of entries to return per page (default: 30)
+- `per_page`: The number of entries to return per page (default: 30, maximum: 100)
 
 For example:
 


### PR DESCRIPTION
When I asked by email, was told that the maximum supported per_page value is 100.